### PR TITLE
MSFT_AdcsCertificationAuthority: Simple fix for two tier PKI deployment fails on initial deployment

### DIFF
--- a/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
+++ b/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
@@ -440,7 +440,7 @@ Function Set-TargetResource
     $null = $adcsParameters.Remove('Debug')
     $null = $adcsParameters.Remove('ErrorAction')
 
-    $errorObject = $Null
+    $resultObject = $Null
 
     if ($CertFilePassword)
     {
@@ -456,12 +456,13 @@ Function Set-TargetResource
                     $($LocalizedData.InstallingAdcsCAMessage -f $CAType)
                 ) -join '' )
 
-            $errorObject = Install-AdcsCertificationAuthority @adcsParameters -Force
+            $resultObject = Install-AdcsCertificationAuthority @adcsParameters -Force
 
-            if (($errorObject.ErrorId -eq 398) -or ($errorObject.ErrorString -like "*The Active Directory Certificate Services installation is incomplete*"))
+            # when a multi-tier ADCS is installed ErrorId 398 is returned, but is only a warning and can be safely ignored
+            if (($resultObject.ErrorId -eq 398) -or ($resultObject.ErrorString -like "*The Active Directory Certificate Services installation is incomplete*"))
             {
-                Write-Warning -Message $errorObject.ErrorString
-                $errorObject = $Null
+                Write-Warning -Message $resultObject.ErrorString
+                $resultObject = $Null
             }
         }
 
@@ -472,13 +473,13 @@ Function Set-TargetResource
                     $($LocalizedData.UninstallingAdcsCAMessage -f $CAType)
                 ) -join '' )
 
-                $errorObject = Uninstall-AdcsCertificationAuthority -Force
+            $resultObject = Uninstall-AdcsCertificationAuthority -Force
         }
     } # switch
 
-    if (-not [System.String]::IsNullOrEmpty($errorObject.ErrorString))
+    if (-not [System.String]::IsNullOrEmpty($resultObject.ErrorString))
     {
-        New-InvalidOperationException -Message $errorObject.ErrorString
+        New-InvalidOperationException -Message $resultObject.ErrorString
     }
 } # Function Set-TargetResource
 

--- a/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
+++ b/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
@@ -457,6 +457,11 @@ Function Set-TargetResource
                 ) -join '' )
 
             $errorMessage = (Install-AdcsCertificationAuthority @adcsParameters -Force).ErrorString
+            if($errorMessage -like "*To complete the installation, use the request file*")
+            {
+                Write-Warning -Message $errorMessage
+                $errorMessage = ''
+            }
         }
 
         'Absent'

--- a/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
+++ b/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
@@ -456,7 +456,7 @@ Function Set-TargetResource
                     $($LocalizedData.InstallingAdcsCAMessage -f $CAType)
                 ) -join '' )
 
-            $errorObject = Install-AdcsCertificationAuthority @adcsParameters -Force | Select-Object -Property ErrorId, ErrorString
+            $errorObject = Install-AdcsCertificationAuthority @adcsParameters -Force
 
             if (($errorObject.ErrorId -eq 398) -or ($errorObject.ErrorString -like "*The Active Directory Certificate Services installation is incomplete*"))
             {
@@ -472,7 +472,7 @@ Function Set-TargetResource
                     $($LocalizedData.UninstallingAdcsCAMessage -f $CAType)
                 ) -join '' )
 
-                $errorObject = Uninstall-AdcsCertificationAuthority -Force | Select-Object -Property ErrorId, ErrorString
+                $errorObject = Uninstall-AdcsCertificationAuthority -Force
         }
     } # switch
 

--- a/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
+++ b/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
@@ -457,7 +457,8 @@ Function Set-TargetResource
                 ) -join '' )
 
             $errorMessage = (Install-AdcsCertificationAuthority @adcsParameters -Force).ErrorString
-            if($errorMessage -like "*To complete the installation, use the request file*")
+
+            if ($errorMessage -like "*c:\windows\system32\certsrv\certenroll\*.req*")
             {
                 Write-Warning -Message $errorMessage
                 $errorMessage = ''

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ For more information on Web Enrollment services, see [this article on TechNet](h
 
 - Updated LICENSE file to match the Microsoft Open Source Team standard.
 - Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #60](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/60).
-- Added fix for two tier PKI deployment fails on initial deployment,  
-  not error - fix [Issue #57](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/57).
+- Added fix for two tier PKI deployment fails on initial deployment,
+  not error - fixes [Issue #57](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/57).
 
 ### 3.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ For more information on Web Enrollment services, see [this article on TechNet](h
 
 - Updated LICENSE file to match the Microsoft Open Source Team standard.
 - Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #60](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/60).
+- Added fix for two tier PKI deployment fails on initial deployment, as this is treated as an error
+[Issue #57](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/57)
 
 ### 3.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,8 @@ For more information on Web Enrollment services, see [this article on TechNet](h
 
 - Updated LICENSE file to match the Microsoft Open Source Team standard.
 - Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #60](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/60).
-- Added fix for two tier PKI deployment fails on initial deployment, as this is treated as an error [Issue #57](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/57)
+- Added fix for two tier PKI deployment fails on initial deployment,  
+  not error - fix [Issue #57](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/57).
 
 ### 3.0.0.0
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,7 @@ For more information on Web Enrollment services, see [this article on TechNet](h
 
 - Updated LICENSE file to match the Microsoft Open Source Team standard.
 - Added .VSCode settings for applying DSC PSSA rules - fixes [Issue #60](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/60).
-- Added fix for two tier PKI deployment fails on initial deployment, as this is treated as an error
-[Issue #57](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/57)
+- Added fix for two tier PKI deployment fails on initial deployment, as this is treated as an error [Issue #57](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/57)
 
 ### 3.0.0.0
 

--- a/Tests/Unit/MSFT_AdcsCertificationAuthority.Tests.ps1
+++ b/Tests/Unit/MSFT_AdcsCertificationAuthority.Tests.ps1
@@ -235,7 +235,7 @@ namespace Microsoft.CertificateServices.Deployment.Common.CA {
             Context 'CA is not installed but should be but an error is thrown installing it' {
                 Mock `
                     -CommandName Install-AdcsCertificationAuthority `
-                    -MockWith { [PSObject] @{ ErrorString = 'Something went wrong' }}
+                    -MockWith { [PSObject] @{ErrorString = 'Something went wrong' }}
 
                 Mock -CommandName Uninstall-AdcsCertificationAuthority
 
@@ -255,6 +255,45 @@ namespace Microsoft.CertificateServices.Deployment.Common.CA {
                         -CommandName Uninstall-AdcsCertificationAuthority `
                         -Exactly `
                         -Times 0
+                }
+            }
+
+            Context 'CA is multi tier and error should not throw for ErrorString with specific text' {
+                Mock `
+                    -CommandName Install-AdcsCertificationAuthority `
+                    -MockWith { [PSObject] @{ErrorString = 'The Active Directory Certificate Services installation is incomplete' }}
+
+                It 'Should not throw exception' {
+
+                    { Set-TargetResource @testParametersPresent } | Should Not Throw
+                }
+
+                It 'Should call expected mocks' {
+                    Assert-MockCalled `
+                        -CommandName Install-AdcsCertificationAuthority `
+                        -Exactly `
+                        -Times 1
+                }
+            }
+
+            Context 'CA is multi tier and error should not throw for Error ID 398' {
+                Mock `
+                    -CommandName Install-AdcsCertificationAuthority `
+                    -MockWith { [PSObject] @{
+                        ErrorID     = 398
+                        ErrorString = 'Something went wrong'
+                    }}
+
+                It 'Should not throw exception' {
+
+                    { Set-TargetResource @testParametersPresent } | Should Not Throw
+                }
+
+                It 'Should call expected mocks' {
+                    Assert-MockCalled `
+                        -CommandName Install-AdcsCertificationAuthority `
+                        -Exactly `
+                        -Times 1
                 }
             }
 

--- a/Tests/Unit/MSFT_AdcsCertificationAuthority.Tests.ps1
+++ b/Tests/Unit/MSFT_AdcsCertificationAuthority.Tests.ps1
@@ -261,7 +261,7 @@ namespace Microsoft.CertificateServices.Deployment.Common.CA {
             Context 'CA is multi tier and error should not throw for ErrorString with specific text' {
                 Mock `
                     -CommandName Install-AdcsCertificationAuthority `
-                    -MockWith { [PSObject] @{ErrorString = 'The Active Directory Certificate Services installation is incomplete' }}
+                    -MockWith { [PSObject] @{ ErrorString = 'The Active Directory Certificate Services installation is incomplete' }}
 
                 It 'Should not throw exception' {
 

--- a/Tests/Unit/MSFT_AdcsCertificationAuthority.Tests.ps1
+++ b/Tests/Unit/MSFT_AdcsCertificationAuthority.Tests.ps1
@@ -258,7 +258,7 @@ namespace Microsoft.CertificateServices.Deployment.Common.CA {
                 }
             }
 
-            Context 'CA is multi tier and error should not throw for ErrorString with specific text' {
+            Context 'When CA is multi tier and error should not throw for ErrorString with specific text' {
                 Mock `
                     -CommandName Install-AdcsCertificationAuthority `
                     -MockWith { [PSObject] @{ ErrorString = 'The Active Directory Certificate Services installation is incomplete' }}
@@ -276,7 +276,7 @@ namespace Microsoft.CertificateServices.Deployment.Common.CA {
                 }
             }
 
-            Context 'CA is multi tier and error should not throw for Error ID 398' {
+            Context 'When CA is multi tier and error should not throw for Error ID 398' {
                 Mock `
                     -CommandName Install-AdcsCertificationAuthority `
                     -MockWith { [PSObject] @{


### PR DESCRIPTION
#### Pull Request (PR) description
Added logic to not treat the following as an error:

The Active Directory Certificate Services installation is incomplete. To complete the installation, use the request file "c:\windows\system32\certsrv\certenroll\<CAname>.req" to obtain a certificate from the parent CA. Then, use the Certification Authority snap-in to install the certificate. To complete this procedure, right-click the node with the name of the CA, and then click Install CA Certificate.

#### This Pull Request (PR) fixes the following issues
-Fixes #57 

#### Task list
- [X] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [X] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/activedirectorycsdsc/65)
<!-- Reviewable:end -->
