### PR TITLE
Converted Switch to If to resolve issues with Break missing - Fixes #87

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Added new resource AdcsTemplate
+- Added new resource AdcsTemplate.
+- Replaced `switch` blocks with `if` blocks for evaluating 'Ensure' parameter
+  because switch was missing `break` - fixes [Issue #87](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/87).
 
 ## 3.3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added new resource AdcsTemplate.
 - Replaced `switch` blocks with `if` blocks for evaluating 'Ensure' parameter
   because switch was missing `break` - fixes [Issue #87](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/87).
+- Added Comment Based Help for `New-NotImplementedException` common function.
 
 ## 3.3.0.0
 

--- a/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
+++ b/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
@@ -445,35 +445,31 @@ Function Set-TargetResource
         $adcsParameters['CertFilePassword'] = $CertFilePassword.Password
     }
 
-    switch ($Ensure)
+    if ($Ensure -eq 'Present')
     {
-        'Present'
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.InstallingAdcsCAMessage -f $CAType)
+            ) -join '' )
+
+        $resultObject = Install-AdcsCertificationAuthority @adcsParameters -Force
+
+        # when a multi-tier ADCS is installed ErrorId 398 is returned, but is only a warning and can be safely ignored
+        if (($resultObject.ErrorId -eq 398) -or ($resultObject.ErrorString -like "*The Active Directory Certificate Services installation is incomplete*"))
         {
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.InstallingAdcsCAMessage -f $CAType)
-                ) -join '' )
-
-            $resultObject = Install-AdcsCertificationAuthority @adcsParameters -Force
-
-            # when a multi-tier ADCS is installed ErrorId 398 is returned, but is only a warning and can be safely ignored
-            if (($resultObject.ErrorId -eq 398) -or ($resultObject.ErrorString -like "*The Active Directory Certificate Services installation is incomplete*"))
-            {
-                Write-Warning -Message $resultObject.ErrorString
-                $resultObject = $Null
-            }
+            Write-Warning -Message $resultObject.ErrorString
+            $resultObject = $Null
         }
+    }
+    else
+    {
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.UninstallingAdcsCAMessage -f $CAType)
+            ) -join '' )
 
-        'Absent'
-        {
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.UninstallingAdcsCAMessage -f $CAType)
-                ) -join '' )
-
-            $resultObject = Uninstall-AdcsCertificationAuthority -Force
-        }
-    } # switch
+        $resultObject = Uninstall-AdcsCertificationAuthority -Force
+    }
 
     if (-not [System.String]::IsNullOrEmpty($resultObject.ErrorString))
     {
@@ -692,58 +688,50 @@ Function Test-TargetResource
     {
         $null = Install-AdcsCertificationAuthority @adcsParameters -WhatIf
         # CA is not installed
-        switch ($Ensure)
+        if ($Ensure -eq 'Present')
         {
-            'Present'
-            {
-                # CA is not installed but should be - change required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsCANotInstalledButShouldBeMessage -f $CAType)
-                    ) -join '' )
+            # CA is not installed but should be - change required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsCANotInstalledButShouldBeMessage -f $CAType)
+                ) -join '' )
 
-                return $false
-            }
+            return $false
+        }
+        else
+        {
+            # CA is not installed and should not be - change not required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsCANotInstalledAndShouldNotBeMessage -f $CAType)
+                ) -join '' )
 
-            'Absent'
-            {
-                # CA is not installed and should not be - change not required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsCANotInstalledAndShouldNotBeMessage -f $CAType)
-                    ) -join '' )
-
-                return $true
-            }
-        } # switch
+            return $true
+        }
     }
     catch [Microsoft.CertificateServices.Deployment.Common.CA.CertificationAuthoritySetupException]
     {
         # CA is already installed
-        switch ($Ensure)
+        if ($Ensure -eq 'Present')
         {
-            'Present'
-            {
-                # CA is installed and should be - change not required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsCAInstalledAndShouldBeMessage -f $CAType)
-                    ) -join '' )
+            # CA is installed and should be - change not required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsCAInstalledAndShouldBeMessage -f $CAType)
+                ) -join '' )
 
-                return $true
-            }
+            return $true
+        }
+        else
+        {
+            # CA is installed and should not be - change required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsCAInstalledButShouldNotBeMessage -f $CAType)
+                ) -join '' )
 
-            'Absent'
-            {
-                # CA is installed and should not be - change required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsCAInstalledButShouldNotBeMessage -f $CAType)
-                    ) -join '' )
-
-                return $false
-            }
-        } # switch
+            return $false
+        }
     }
     catch
     {

--- a/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
+++ b/DSCResources/MSFT_AdcsCertificationAuthority/MSFT_AdcsCertificationAuthority.psm1
@@ -229,7 +229,7 @@ Function Get-TargetResource
     catch
     {
         # Something else went wrong
-        Throw $_
+        throw $_
     }
 
     return @{
@@ -736,7 +736,7 @@ Function Test-TargetResource
     catch
     {
         # Something else went wrong
-        Throw $_
+        throw $_
     } # try
 } # Function Test-TargetResource
 

--- a/DSCResources/MSFT_AdcsEnrollmentPolicyWebService/MSFT_AdcsEnrollmentPolicyWebService.psm1
+++ b/DSCResources/MSFT_AdcsEnrollmentPolicyWebService/MSFT_AdcsEnrollmentPolicyWebService.psm1
@@ -161,31 +161,27 @@ Function Set-TargetResource
 
     try
     {
-        switch ($Ensure)
+        if ($Ensure -eq 'Present')
         {
-            'Present'
-            {
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.InstallingAdcsEnrollmentPolicyWebServiceMessage -f $AuthenticationType)
-                    ) -join '' )
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.InstallingAdcsEnrollmentPolicyWebServiceMessage -f $AuthenticationType)
+                ) -join '' )
 
-                $errorMessage = (Install-AdcsEnrollmentPolicyWebService @adcsEnrollmentPolicyWebServiceParameters -Force).ErrorString
-            }
+            $errorMessage = (Install-AdcsEnrollmentPolicyWebService @adcsEnrollmentPolicyWebServiceParameters -Force).ErrorString
+        }
+        else
+        {
+            $null = $adcsEnrollmentPolicyWebServiceParameters.Remove('SslCertThumbprint')
+            $null = $adcsEnrollmentPolicyWebServiceParameters.Remove('Credential')
 
-            'Absent'
-            {
-                $null = $adcsEnrollmentPolicyWebServiceParameters.Remove('SslCertThumbprint')
-                $null = $adcsEnrollmentPolicyWebServiceParameters.Remove('Credential')
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.UninstallingAdcsEnrollmentPolicyWebServiceMessage -f $AuthenticationType)
+                ) -join '' )
 
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.UninstallingAdcsEnrollmentPolicyWebServiceMessage -f $AuthenticationType)
-                    ) -join '' )
-
-                $errorMessage = (Uninstall-AdcsEnrollmentPolicyWebService @adcsEnrollmentPolicyWebServiceParameters -Force).ErrorString
-            }
-        } # switch
+            $errorMessage = (Uninstall-AdcsEnrollmentPolicyWebService @adcsEnrollmentPolicyWebServiceParameters -Force).ErrorString
+        }
     }
     catch
     {
@@ -274,58 +270,50 @@ Function Test-TargetResource
     if ($installed -eq $true)
     {
         # Enrollment Policy Web Service is already installed
-        switch ($Ensure)
+        if ($Ensure -eq 'Present')
         {
-            'Present'
-            {
-                # CA is installed and should be - change not required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsEnrollmentPolicyWebServiceInstalledAndShouldBeMessage -f $AuthenticationType)
-                    ) -join '' )
+            # CA is installed and should be - change not required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsEnrollmentPolicyWebServiceInstalledAndShouldBeMessage -f $AuthenticationType)
+                ) -join '' )
 
-                return $true
-            }
+            return $true
+        }
+        else
+        {
+            # CA is installed and should not be - change required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsEnrollmentPolicyWebServiceInstalledButShouldNotBeMessage -f $AuthenticationType)
+                ) -join '' )
 
-            'Absent'
-            {
-                # CA is installed and should not be - change required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsEnrollmentPolicyWebServiceInstalledButShouldNotBeMessage -f $AuthenticationType)
-                    ) -join '' )
-
-                return $false
-            }
-        } # switch
+            return $false
+        }
     }
     else
     {
         # Enrollment Policy Web Service is not installed
-        switch ($Ensure)
+        if ($Ensure -eq 'Present')
         {
-            'Present'
-            {
-                # CA is not installed but should be - change required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsEnrollmentPolicyWebServiceNotInstalledButShouldBeMessage -f $AuthenticationType)
-                    ) -join '' )
+            # CA is not installed but should be - change required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsEnrollmentPolicyWebServiceNotInstalledButShouldBeMessage -f $AuthenticationType)
+                ) -join '' )
 
-                return $false
-            }
+            return $false
+        }
+        else
+        {
+            # CA is not installed and should not be - change not required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsEnrollmentPolicyWebServiceNotInstalledAndShouldNotBeMessage -f $AuthenticationType)
+                ) -join '' )
 
-            'Absent'
-            {
-                # CA is not installed and should not be - change not required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsEnrollmentPolicyWebServiceNotInstalledAndShouldNotBeMessage -f $AuthenticationType)
-                    ) -join '' )
-
-                return $true
-            }
-        } # switch
+            return $true
+        }
     }
 } # Function Test-TargetResource
 

--- a/DSCResources/MSFT_AdcsOnlineResponder/MSFT_AdcsOnlineResponder.psm1
+++ b/DSCResources/MSFT_AdcsOnlineResponder/MSFT_AdcsOnlineResponder.psm1
@@ -74,7 +74,7 @@ Function Get-TargetResource
     catch
     {
         # Something else went wrong
-        Throw $_
+        throw $_
     }
 
     return @{
@@ -262,7 +262,7 @@ Function Test-TargetResource
     catch
     {
         # Something else went wrong
-        Throw $_
+        throw $_
     } # try
 } # Function Test-TargetResource
 

--- a/DSCResources/MSFT_AdcsOnlineResponder/MSFT_AdcsOnlineResponder.psm1
+++ b/DSCResources/MSFT_AdcsOnlineResponder/MSFT_AdcsOnlineResponder.psm1
@@ -133,28 +133,24 @@ Function Set-TargetResource
 
     $errorMessage = ''
 
-    switch ($Ensure)
+    if ($Ensure -eq 'Present')
     {
-        'Present'
-        {
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.InstallingAdcsOnlineResponderMessage)
-                ) -join '' )
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.InstallingAdcsOnlineResponderMessage)
+            ) -join '' )
 
-            $errorMessage = (Install-AdcsOnlineResponder @adcsParameters -Force).ErrorString
-        }
+        $errorMessage = (Install-AdcsOnlineResponder @adcsParameters -Force).ErrorString
+    }
+    else
+    {
+    Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.UninstallingAdcsOnlineResponderMessage)
+            ) -join '' )
 
-        'Absent'
-        {
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.UninstallingAdcsOnlineResponderMessage)
-                ) -join '' )
-
-            $errorMessage = (Uninstall-AdcsOnlineResponder -Force).ErrorString
-        }
-    } # switch
+        $errorMessage = (Uninstall-AdcsOnlineResponder -Force).ErrorString
+    }
 
     if (-not [System.String]::IsNullOrEmpty($errorMessage))
     {
@@ -218,58 +214,50 @@ Function Test-TargetResource
     {
         $null = Install-AdcsOnlineResponder @adcsParameters -WhatIf
         # Online Responder is not installed
-        switch ($Ensure)
+        if ($Ensure -eq 'Present')
         {
-            'Present'
-            {
-                # Online Responder is not installed but should be - change required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsOnlineResponderNotInstalledButShouldBeMessage)
-                    ) -join '' )
+            # Online Responder is not installed but should be - change required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsOnlineResponderNotInstalledButShouldBeMessage)
+                ) -join '' )
 
-                return $false
-            }
+            return $false
+        }
+        else
+        {
+            # Online Responder is not installed and should not be - change not required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsOnlineResponderNotInstalledAndShouldNotBeMessage)
+                ) -join '' )
 
-            'Absent'
-            {
-                # Online Responder is not installed and should not be - change not required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsOnlineResponderNotInstalledAndShouldNotBeMessage)
-                    ) -join '' )
-
-                return $true
-            }
-        } # switch
+            return $true
+        }
     }
     catch [Microsoft.CertificateServices.Deployment.Common.OCSP.OnlineResponderSetupException]
     {
         # Online Responder is already installed
-        switch ($Ensure)
+        if ($Ensure -eq 'Present')
         {
-            'Present'
-            {
-                # Online Responder is installed and should be - change not required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsOnlineResponderInstalledAndShouldBeMessage)
-                    ) -join '' )
+            # Online Responder is installed and should be - change not required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsOnlineResponderInstalledAndShouldBeMessage)
+                ) -join '' )
 
-                return $true
-            }
+            return $true
+        }
+        else
+        {
+            # Online Responder is installed and should not be - change required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsOnlineResponderInstalledButShouldNotBeMessage)
+                ) -join '' )
 
-            'Absent'
-            {
-                # Online Responder is installed and should not be - change required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsOnlineResponderInstalledButShouldNotBeMessage)
-                    ) -join '' )
-
-                return $false
-            }
-        } # switch
+            return $false
+        }
     }
     catch
     {

--- a/DSCResources/MSFT_AdcsTemplate/MSFT_AdcsTemplate.psm1
+++ b/DSCResources/MSFT_AdcsTemplate/MSFT_AdcsTemplate.psm1
@@ -92,42 +92,38 @@ Function Set-TargetResource
             $($script:localizedData.SettingAdcsTemplateStatusMessage -f $Name)
         ) -join '' )
 
-    switch ($Ensure)
+    if ($Ensure -eq 'Present')
     {
-        'Present'
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.AddingAdcsTemplateMessage -f $Name)
+            ) -join '' )
+
+        try
         {
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.AddingAdcsTemplateMessage -f $Name)
-                ) -join '' )
-
-            try
-            {
-                Add-CATemplate -Name $Name -Verbose:$false
-            }
-            catch
-            {
-                New-InvalidOperationException -Message $($script:localizedData.InvalidOperationAddingAdcsTemplateMessage -f $Name) -ErrorRecord $_
-            }
+            Add-CATemplate -Name $Name -Verbose:$false
         }
-
-        'Absent'
+        catch
         {
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.RemovingAdcsTemplateMessage -f $Name)
-                ) -join '' )
-
-            try
-            {
-                Remove-CATemplate -Name $Name -Force -Verbose:$false
-            }
-            catch
-            {
-                New-InvalidOperationException -Message $($script:localizedData.InvalidOperationRemovingAdcsTemplateMessage -f $Name) -ErrorRecord $_
-            }
+            New-InvalidOperationException -Message $($script:localizedData.InvalidOperationAddingAdcsTemplateMessage -f $Name) -ErrorRecord $_
         }
-    } # switch
+    }
+    else
+    {
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.RemovingAdcsTemplateMessage -f $Name)
+            ) -join '' )
+
+        try
+        {
+            Remove-CATemplate -Name $Name -Force -Verbose:$false
+        }
+        catch
+        {
+            New-InvalidOperationException -Message $($script:localizedData.InvalidOperationRemovingAdcsTemplateMessage -f $Name) -ErrorRecord $_
+        }
+    }
 } # Function Set-TargetResource
 
 <#
@@ -166,59 +162,50 @@ Function Test-TargetResource
         ) -join '' )
 
     $currentState = Get-TargetResource -Name $Name
-    switch ($Ensure)
+    if ($Ensure -eq 'Present')
     {
-        'Present'
+        if ($currentState.Ensure -eq 'Present')
         {
-            switch ($currentState.Ensure)
-            {
-                'Present'
-                {
-                    # CA Template is added and should be - change not required
-                    Write-Verbose -Message ( @(
-                            "$($MyInvocation.MyCommand): "
-                            $($script:localizedData.AdcsTemplateAddedAndShouldBeMessage -f $Name)
-                        ) -join '' )
+            # CA Template is added and should be - change not required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsTemplateAddedAndShouldBeMessage -f $Name)
+                ) -join '' )
 
-                    return $true
-                }
-                'Absent'
-                {
-                    # CA Template is not added but should be - change required
-                    Write-Verbose -Message ( @(
-                            "$($MyInvocation.MyCommand): "
-                            $($script:localizedData.AdcsTemplateNotAddedButShouldBeMessage -f $Name)
-                        ) -join '' )
-
-                    return $false
-                }
-            }
+            return $true
         }
-        'Absent'
+        else
         {
-            switch ($currentState.Ensure)
-            {
-                'Present'
-                {
-                    # CA Template is installed and should not be - change required
-                    Write-Verbose -Message ( @(
-                            "$($MyInvocation.MyCommand): "
-                            $($script:localizedData.AdcsTemplateAddedButShouldNotBeMessage -f $Name)
-                        ) -join '' )
+            # CA Template is not added but should be - change required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsTemplateNotAddedButShouldBeMessage -f $Name)
+                ) -join '' )
 
-                    return $false
-                }
-                'Absent'
-                {
-                    # CA Template is not added and should not be - change not required
-                    Write-Verbose -Message ( @(
-                            "$($MyInvocation.MyCommand): "
-                            $($script:localizedData.AdcsTemplateNotAddedAndShouldNotBeMessage -f $Name)
-                        ) -join '' )
+            return $false
+        }
+    }
+    else
+    {
+        if ($currentState.Ensure -eq 'Present')
+        {
+            # CA Template is installed and should not be - change required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsTemplateAddedButShouldNotBeMessage -f $Name)
+                ) -join '' )
 
-                    return $true
-                }
-            }
+            return $false
+        }
+        else
+        {
+            # CA Template is not added and should not be - change not required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsTemplateNotAddedAndShouldNotBeMessage -f $Name)
+                ) -join '' )
+
+            return $true
         }
     }
 } # Function Test-TargetResource

--- a/DSCResources/MSFT_AdcsWebEnrollment/MSFT_AdcsWebEnrollment.psm1
+++ b/DSCResources/MSFT_AdcsWebEnrollment/MSFT_AdcsWebEnrollment.psm1
@@ -148,28 +148,24 @@ Function Set-TargetResource
 
     $errorMessage = ''
 
-    switch ($Ensure)
+    if ($Ensure -eq 'Present')
     {
-        'Present'
-        {
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.InstallingAdcsWebEnrollmentMessage)
-                ) -join '' )
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.InstallingAdcsWebEnrollmentMessage)
+            ) -join '' )
 
-            $errorMessage = (Install-AdcsWebEnrollment @adcsParameters -Force).ErrorString
-        }
+        $errorMessage = (Install-AdcsWebEnrollment @adcsParameters -Force).ErrorString
+    }
+    else
+    {
+        Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.UninstallingAdcsWebEnrollmentMessage)
+            ) -join '' )
 
-        'Absent'
-        {
-            Write-Verbose -Message ( @(
-                    "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.UninstallingAdcsWebEnrollmentMessage)
-                ) -join '' )
-
-            $errorMessage = (Uninstall-AdcsWebEnrollment -Force).ErrorString
-        }
-    } # switch
+        $errorMessage = (Uninstall-AdcsWebEnrollment -Force).ErrorString
+    }
 
     if (-not [System.String]::IsNullOrEmpty($errorMessage))
     {
@@ -241,58 +237,50 @@ Function Test-TargetResource
     {
         $null = Install-AdcsWebEnrollment @adcsParameters -WhatIf
         # Web Enrollment is not installed
-        switch ($Ensure)
+        if ($Ensure -eq 'Present')
         {
-            'Present'
-            {
-                # Web Enrollment is not installed but should be - change required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsWebEnrollmentNotInstalledButShouldBeMessage)
-                    ) -join '' )
+            # Web Enrollment is not installed but should be - change required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsWebEnrollmentNotInstalledButShouldBeMessage)
+                ) -join '' )
 
-                return $false
-            }
+            return $false
+        }
+        else
+        {
+            # Web Enrollment is not installed and should not be - change not required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsWebEnrollmentNotInstalledAndShouldNotBeMessage)
+                ) -join '' )
 
-            'Absent'
-            {
-                # Web Enrollment is not installed and should not be - change not required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsWebEnrollmentNotInstalledAndShouldNotBeMessage)
-                    ) -join '' )
-
-                return $true
-            }
-        } # switch
+            return $true
+        }
     }
     catch [Microsoft.CertificateServices.Deployment.Common.WEP.WebEnrollmentSetupException]
     {
         # Web Enrollment is already installed
-        switch ($Ensure)
+        if ($Ensure -eq 'Present')
         {
-            'Present'
-            {
-                # Web Enrollment is installed and should be - change not required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsWebEnrollmentInstalledAndShouldBeMessage)
-                    ) -join '' )
+            # Web Enrollment is installed and should be - change not required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsWebEnrollmentInstalledAndShouldBeMessage)
+                ) -join '' )
 
-                return $true
-            }
+            return $true
+        }
+        else
+        {
+            # Web Enrollment is installed and should not be - change required
+            Write-Verbose -Message ( @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.AdcsWebEnrollmentInstalledButShouldNotBeMessage)
+                ) -join '' )
 
-            'Absent'
-            {
-                # Web Enrollment is installed and should not be - change required
-                Write-Verbose -Message ( @(
-                        "$($MyInvocation.MyCommand): "
-                        $($script:localizedData.AdcsWebEnrollmentInstalledButShouldNotBeMessage)
-                    ) -join '' )
-
-                return $false
-            }
-        } # switch
+            return $false
+        }
     }
     catch
     {

--- a/DSCResources/MSFT_AdcsWebEnrollment/MSFT_AdcsWebEnrollment.psm1
+++ b/DSCResources/MSFT_AdcsWebEnrollment/MSFT_AdcsWebEnrollment.psm1
@@ -81,7 +81,7 @@ Function Get-TargetResource
     catch
     {
         # Something else went wrong
-        Throw $_
+        throw $_
     }
 
     return @{
@@ -285,7 +285,7 @@ Function Test-TargetResource
     catch
     {
         # Something else went wrong
-        Throw $_
+        throw $_
     } # try
 } # Function Test-TargetResource
 

--- a/Modules/ActiveDirectoryCSDsc.Common/ActiveDirectoryCSDsc.Common.psm1
+++ b/Modules/ActiveDirectoryCSDsc.Common/ActiveDirectoryCSDsc.Common.psm1
@@ -1,5 +1,3 @@
-$script:modulesFolderPath = Split-Path -Path $PSScriptRoot -Parent
-
 <#
     .SYNOPSIS
         This method is used to compare current and desired values for any DSC resource.

--- a/Modules/ActiveDirectoryCSDsc.Common/ActiveDirectoryCSDsc.Common.psm1
+++ b/Modules/ActiveDirectoryCSDsc.Common/ActiveDirectoryCSDsc.Common.psm1
@@ -436,6 +436,16 @@ function New-InvalidResultException
     throw $errorRecordToThrow
 }
 
+<#
+    .SYNOPSIS
+        Creates and throws a not implemented exception.
+
+    .PARAMETER Message
+        The message explaining why this error is being thrown.
+
+    .PARAMETER ErrorRecord
+        The error record containing the exception that is causing this terminating error.
+#>
 function New-NotImplementedException
 {
     [CmdletBinding()]


### PR DESCRIPTION
#### Pull Request (PR) description

- Replaced `switch` blocks with `if` blocks for evaluating 'Ensure' parameter
  because switch was missing `break` - fixes [Issue #87](https://github.com/PowerShell/ActiveDirectoryCSDsc/issues/87).

#### This Pull Request (PR) fixes the following issues

- Fixes #87

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing this for me?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/activedirectorycsdsc/89)
<!-- Reviewable:end -->
